### PR TITLE
Send apprec ved ingest

### DIFF
--- a/naiserator-dev.yaml
+++ b/naiserator-dev.yaml
@@ -70,3 +70,5 @@ spec:
       value: 32e36aa5-1d12-452a-9b1e-9f3f557cbb4d
     - name: OPPGAVEBEHANDLING_URL
       value: https://oppgave-q1.nais.preprod.local/api/v1/oppgaver
+    - name: SYFOTILGANGSKONTROLL_URL
+      value: https://syfo-tilgangskontroll.nais.preprod.local/syfo-tilgangskontroll

--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -70,3 +70,5 @@ spec:
       value: dfaa2699-7390-4459-9cfc-2e8de64dfaf9
     - name: OPPGAVEBEHANDLING_URL
       value: https://oppgave.nais.adeo.no/api/v1/oppgaver
+    - name: SYFOTILGANGSKONTROLL_URL
+      value: https://syfo-tilgangskontroll.nais.adeo.no/syfo-tilgangskontroll

--- a/src/main/kotlin/no/nav/syfo/Bootstrap.kt
+++ b/src/main/kotlin/no/nav/syfo/Bootstrap.kt
@@ -106,6 +106,7 @@ fun main() {
         kafkaConsumers,
         database,
         oppgaveService,
+        manuellOppgaveService,
         brukernotifikasjonService
     )
 }
@@ -132,6 +133,7 @@ fun launchListeners(
     kafkaConsumers: KafkaConsumers,
     database: Database,
     oppgaveService: OppgaveService,
+    manuellOppgaveService: ManuellOppgaveService,
     brukernotifikasjonService: BrukernotifikasjonService
 ) {
     createListener(applicationState) {
@@ -143,6 +145,7 @@ fun launchListeners(
             kafkaConsumerManuellOppgave,
             database,
             oppgaveService,
+            manuellOppgaveService,
             brukernotifikasjonService
         )
     }
@@ -154,6 +157,7 @@ suspend fun blockingApplicationLogic(
     kafkaConsumer: KafkaConsumer<String, String>,
     database: Database,
     oppgaveService: OppgaveService,
+    manuellOppgaveService: ManuellOppgaveService,
     brukernotifikasjonService: BrukernotifikasjonService
 ) {
     while (applicationState.ready) {
@@ -171,6 +175,7 @@ suspend fun blockingApplicationLogic(
                 loggingMeta,
                 database,
                 oppgaveService,
+                manuellOppgaveService,
                 brukernotifikasjonService
             )
         }

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -20,7 +20,7 @@ data class Environment(
     val syfosmmanuellUrl: String = getEnvVar("SYFOSMMANUELL_URL"),
     val sm2013BehandlingsUtfallTopic: String = getEnvVar("KAFKA_SM2013_BEHANDLING_TOPIC", "privat-syfo-sm2013-behandlingsUtfall"),
     val oppgavebehandlingUrl: String = getEnvVar("OPPGAVEBEHANDLING_URL"),
-    val syfoTilgangsKontrollClientUrl: String = getEnvVar("SYFOTILGANGSKONTROLL_URL", "http://syfo-tilgangskontroll/syfo-tilgangskontroll"),
+    val syfoTilgangsKontrollClientUrl: String = getEnvVar("SYFOTILGANGSKONTROLL_URL"),
     val jwkKeysUrl: String = getEnvVar("JWKKEYS_URL", "https://login.microsoftonline.com/common/discovery/keys"),
     val jwtIssuer: String = getEnvVar("JWT_ISSUER"),
     val securityTokenUrl: String = getEnvVar("SECURITY_TOKEN_SERVICE_URL", "http://security-token-service/rest/v1/sts/token"),

--- a/src/main/kotlin/no/nav/syfo/Environment.kt
+++ b/src/main/kotlin/no/nav/syfo/Environment.kt
@@ -16,7 +16,6 @@ data class Environment(
     val syfoSmManuellTopic: String = getEnvVar("KAFKA_SYFO_SM_MANUELL_TOPIC", "privat-syfo-sm2013-manuell"),
     val sm2013Apprec: String = getEnvVar("KAFKA_SM2013_BEHANDLING_TOPIC", "privat-syfo-sm2013-apprec-v1"),
     val sm2013AutomaticHandlingTopic: String = getEnvVar("KAFKA_SM2013_AUTOMATIC_TOPIC", "privat-syfo-sm2013-automatiskBehandling"),
-    val sm2013InvalidHandlingTopic: String = getEnvVar("KAFKA_SM2013_INVALID_TOPIC", "privat-syfo-sm2013-avvistBehandling"),
     val sm2013OpppgaveTopic: String = getEnvVar("KAFKA_SM2013_OPPGAVE_TOPIC", "aapen-syfo-oppgave-produserOppgave"),
     val syfosmmanuellUrl: String = getEnvVar("SYFOSMMANUELL_URL"),
     val sm2013BehandlingsUtfallTopic: String = getEnvVar("KAFKA_SM2013_BEHANDLING_TOPIC", "privat-syfo-sm2013-behandlingsUtfall"),

--- a/src/main/kotlin/no/nav/syfo/aksessering/db/ManuellOppgaveAksesseringQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/aksessering/db/ManuellOppgaveAksesseringQueries.kt
@@ -23,6 +23,22 @@ fun DatabaseInterface.finnesOppgave(oppgaveId: Int) =
             }
         }
 
+fun DatabaseInterface.erApprecSendt(oppgaveId: Int) =
+        connection.use { connection ->
+            connection.prepareStatement(
+                    """
+                SELECT *
+                FROM MANUELLOPPGAVE
+                WHERE oppgaveid=?
+                AND sendt_apprec=?;
+                """
+            ).use {
+                it.setInt(1, oppgaveId)
+                it.setBoolean(2, true)
+                it.executeQuery().next()
+            }
+        }
+
 fun DatabaseInterface.hentManuellOppgaver(oppgaveId: Int): ManuellOppgaveDTO? =
     connection.use { connection ->
         connection.prepareStatement(
@@ -54,7 +70,7 @@ fun DatabaseInterface.hentKomplettManuellOppgave(oppgaveId: Int): List<ManuellOp
     connection.use { connection ->
         connection.prepareStatement(
             """
-                SELECT receivedsykmelding,validationresult,apprec,oppgaveid,ferdigstilt
+                SELECT receivedsykmelding,validationresult,apprec,oppgaveid,ferdigstilt,sendt_apprec
                 FROM MANUELLOPPGAVE  
                 WHERE oppgaveid=?;
                 """
@@ -70,5 +86,6 @@ fun ResultSet.toManuellOppgave(): ManuellOppgaveKomplett =
         validationResult = objectMapper.readValue(getString("validationresult")),
         apprec = objectMapper.readValue(getString("apprec")),
         oppgaveid = getInt("oppgaveid"),
-        ferdigstilt = getBoolean("ferdigstilt")
+        ferdigstilt = getBoolean("ferdigstilt"),
+        sendtApprec = getBoolean("sendt_apprec")
     )

--- a/src/main/kotlin/no/nav/syfo/clients/KafkaProducers.kt
+++ b/src/main/kotlin/no/nav/syfo/clients/KafkaProducers.kt
@@ -10,7 +10,6 @@ import no.nav.syfo.kafka.model.SyfoserviceSykmeldingKafkaMessage
 import no.nav.syfo.kafka.toProducerConfig
 import no.nav.syfo.model.Apprec
 import no.nav.syfo.model.ReceivedSykmelding
-import no.nav.syfo.model.ValidationResult
 import no.nav.syfo.sak.avro.ProduceTask
 import no.nav.syfo.util.JacksonKafkaSerializer
 import no.nav.syfo.util.setSecurityProtocol
@@ -27,7 +26,6 @@ class KafkaProducers(private val env: Environment, vaultSecrets: VaultSecrets) {
 
     val kafkaApprecProducer = KafkaApprecProducer()
     val kafkaRecievedSykmeldingProducer = KafkaRecievedSykmeldingProducer()
-    val kafkaValidationResultProducer = KafkaValidationResultProducer()
     val kafkaSyfoserviceProducer = KafkaSyfoserviceProducer()
     val kafkaBrukernotifikasjonProducer = BrukernotifikasjonProducer()
     val kafkaProduceTaskProducer = KafkaProduceTaskProducer()
@@ -40,12 +38,6 @@ class KafkaProducers(private val env: Environment, vaultSecrets: VaultSecrets) {
     inner class KafkaRecievedSykmeldingProducer() {
         val producer = KafkaProducer<String, ReceivedSykmelding>(properties)
         val sm2013AutomaticHandlingTopic = env.sm2013AutomaticHandlingTopic
-        val sm2013InvalidHandlingTopic = env.sm2013InvalidHandlingTopic
-    }
-
-    inner class KafkaValidationResultProducer() {
-        val producer = KafkaProducer<String, ValidationResult>(properties)
-        val sm2013BehandlingsUtfallTopic = env.sm2013BehandlingsUtfallTopic
     }
 
     inner class KafkaSyfoserviceProducer() {

--- a/src/main/kotlin/no/nav/syfo/model/ManuellOppgaveKomplett.kt
+++ b/src/main/kotlin/no/nav/syfo/model/ManuellOppgaveKomplett.kt
@@ -5,7 +5,8 @@ data class ManuellOppgaveKomplett(
     val validationResult: ValidationResult,
     val apprec: Apprec,
     val oppgaveid: Int,
-    val ferdigstilt: Boolean
+    val ferdigstilt: Boolean,
+    val sendtApprec: Boolean
 ) {
     fun addMerknader(merknadList: List<Merknad>?): ManuellOppgaveKomplett {
         if (merknadList.isNullOrEmpty()) {

--- a/src/main/kotlin/no/nav/syfo/persistering/HandleReceivedMessage.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/HandleReceivedMessage.kt
@@ -37,7 +37,6 @@ suspend fun handleReceivedMessage(
         } else {
             try {
                 val oppgaveId = oppgaveService.opprettOppgave(manuellOppgave, loggingMeta)
-
                 val oppdatertApprec = manuellOppgaveService.lagOppdatertApprec(manuellOppgave)
 
                 database.opprettManuellOppgave(manuellOppgave, oppdatertApprec, oppgaveId)
@@ -46,7 +45,7 @@ suspend fun handleReceivedMessage(
                     StructuredArguments.keyValue("oppgaveId", oppgaveId),
                     fields(loggingMeta)
                 )
-                manuellOppgaveService.sendApprec(oppdatertApprec, loggingMeta)
+                manuellOppgaveService.sendApprec(oppgaveId, oppdatertApprec, loggingMeta)
                 brukernotifikasjonService.sendBrukerNotifikasjon(manuellOppgave)
                 MESSAGE_STORED_IN_DB_COUNTER.inc()
             } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/syfo/persistering/api/SendVurderingManuellOppgaveRest.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/api/SendVurderingManuellOppgaveRest.kt
@@ -11,7 +11,6 @@ import io.ktor.util.KtorExperimentalAPI
 import no.nav.syfo.authorization.service.AuthorizationService
 import no.nav.syfo.log
 import no.nav.syfo.model.Merknad
-import no.nav.syfo.model.RuleInfo
 import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
 import no.nav.syfo.service.ManuellOppgaveService
@@ -82,14 +81,12 @@ enum class AvvisningType {
 
 enum class ResultStatus {
     GODKJENT,
-    GODKJENT_MED_MERKNAD,
-    AVVIST
+    GODKJENT_MED_MERKNAD
 }
 
 data class Result(
     val status: ResultStatus,
-    val merknad: MerknadType?,
-    val avvisningType: AvvisningType?
+    val merknad: MerknadType?
 ) {
     fun toMerknad(): Merknad? {
         return when (status) {
@@ -120,39 +117,6 @@ data class Result(
         return when (status) {
             ResultStatus.GODKJENT -> ValidationResult(Status.OK, emptyList())
             ResultStatus.GODKJENT_MED_MERKNAD -> ValidationResult(Status.OK, emptyList())
-            ResultStatus.AVVIST -> {
-                return when (avvisningType) {
-                    AvvisningType.MANGLER_BEGRUNNELSE -> {
-                        ValidationResult(
-                            Status.INVALID,
-                            listOf(
-                                RuleInfo(
-                                    ruleName = "TILBAKEDATERT_MANGLER_BEGRUNNELSE",
-                                    messageForSender = "Sykmelding gjelder som hovedregel fra den dagen pasienten oppsøker behandler. Sykmeldingen er tilbakedatert uten at det kommer tydelig nok fram hvorfor dette var nødvendig. Sykmeldingen er derfor avvist, og det må skrives en ny hvis det fortsatt er aktuelt med sykmelding. Pasienten har fått beskjed om å vente på ny sykmelding fra deg.",
-                                    messageForUser = "Sykmelding gjelder som hovedregel fra den dagen du oppsøker behandler. Sykmeldingen din er tilbakedatert uten at det er gitt en god nok begrunnelse for dette. Behandleren din må skrive ut en ny sykmelding og begrunne bedre hvorfor den er tilbakedatert. Din behandler har mottatt melding fra NAV om dette.",
-                                    ruleStatus = Status.INVALID
-                                )
-                            )
-                        )
-                    }
-                    AvvisningType.UGYLDIG_BEGRUNNELSE -> {
-                        ValidationResult(
-                            Status.INVALID,
-                            listOf(
-                                RuleInfo(
-                                    ruleName = "UGYLDIG_BEGRUNNELSE",
-                                    messageForSender = "NAV kan ikke godta tilbakedateringen. Sykmeldingen er derfor avvist. Hvis sykmelding fortsatt er aktuelt, må det skrives ny sykmelding der f.o.m.-dato er dagen du var i kontakt med pasienten. Pasienten har fått beskjed om å vente på ny sykmelding fra deg.",
-                                    messageForUser = "NAV kan ikke godta sykmeldingen din fordi den starter før dagen du tok kontakt med behandleren. Trenger du fortsatt sykmelding, må behandleren din skrive en ny som gjelder fra den dagen dere var i kontakt. Behandleren din har fått beskjed fra NAV om dette.",
-                                    ruleStatus = Status.INVALID
-                                )
-                            )
-                        )
-                    }
-                    else -> {
-                        throw IllegalArgumentException("Result with status AVVIST missing avvisningtype property")
-                    }
-                }
-            }
         }
     }
 }

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
@@ -71,7 +71,7 @@ fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, receivedSykmelding:
             return status
         }
 
-fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, sendtApprec: Boolean): Int =
+fun DatabaseInterface.oppdaterApprecStatus(oppgaveId: Int, sendtApprec: Boolean): Int =
         connection.use { connection ->
             val status = connection.prepareStatement(
                     """

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
@@ -6,7 +6,7 @@ import no.nav.syfo.model.ManuellOppgave
 import no.nav.syfo.model.ReceivedSykmelding
 import no.nav.syfo.model.toPGObject
 
-fun DatabaseInterface.opprettManuellOppgave(manuellOppgave: ManuellOppgave, oppgaveId: Int) {
+fun DatabaseInterface.opprettManuellOppgave(manuellOppgave: ManuellOppgave, apprec: Apprec, oppgaveId: Int) {
     connection.use { connection ->
         connection.prepareStatement(
                 """
@@ -25,7 +25,7 @@ fun DatabaseInterface.opprettManuellOppgave(manuellOppgave: ManuellOppgave, oppg
             it.setString(1, manuellOppgave.receivedSykmelding.sykmelding.id)
             it.setObject(2, manuellOppgave.receivedSykmelding.toPGObject())
             it.setObject(3, manuellOppgave.validationResult.toPGObject())
-            it.setObject(4, manuellOppgave.apprec.toPGObject())
+            it.setObject(4, apprec.toPGObject())
             it.setString(5, manuellOppgave.receivedSykmelding.personNrPasient)
             it.setBoolean(6, false)
             it.setInt(7, oppgaveId)
@@ -50,21 +50,19 @@ fun DatabaseInterface.erOpprettManuellOppgave(sykmledingsId: String) =
             }
         }
 
-fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, receivedSykmelding: ReceivedSykmelding, apprec: Apprec): Int =
+fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, receivedSykmelding: ReceivedSykmelding): Int =
         connection.use { connection ->
             val status = connection.prepareStatement(
                     """
             UPDATE MANUELLOPPGAVE
             SET ferdigstilt = ?,
-                apprec = ?,
                 receivedsykmelding = ?
             WHERE oppgaveid = ?;
             """
             ).use {
                 it.setBoolean(1, true)
-                it.setObject(2, apprec.toPGObject())
-                it.setObject(3, receivedSykmelding.toPGObject())
-                it.setInt(4, oppgaveId)
+                it.setObject(2, receivedSykmelding.toPGObject())
+                it.setInt(3, oppgaveId)
                 it.executeUpdate()
             }
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
+++ b/src/main/kotlin/no/nav/syfo/persistering/db/PersisterManuellOppgaveQueries.kt
@@ -17,9 +17,10 @@ fun DatabaseInterface.opprettManuellOppgave(manuellOppgave: ManuellOppgave, appr
                 apprec,
                 pasientfnr,
                 ferdigstilt,
-                oppgaveid
+                oppgaveid,
+                sendt_apprec
                 )
-            VALUES  (?, ?, ?, ?, ?, ?, ?)
+            VALUES  (?, ?, ?, ?, ?, ?, ?, ?)
             """
         ).use {
             it.setString(1, manuellOppgave.receivedSykmelding.sykmelding.id)
@@ -29,6 +30,7 @@ fun DatabaseInterface.opprettManuellOppgave(manuellOppgave: ManuellOppgave, appr
             it.setString(5, manuellOppgave.receivedSykmelding.personNrPasient)
             it.setBoolean(6, false)
             it.setInt(7, oppgaveId)
+            it.setBoolean(8, false)
             it.executeUpdate()
         }
 
@@ -63,6 +65,23 @@ fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, receivedSykmelding:
                 it.setBoolean(1, true)
                 it.setObject(2, receivedSykmelding.toPGObject())
                 it.setInt(3, oppgaveId)
+                it.executeUpdate()
+            }
+            connection.commit()
+            return status
+        }
+
+fun DatabaseInterface.oppdaterManuellOppgave(oppgaveId: Int, sendtApprec: Boolean): Int =
+        connection.use { connection ->
+            val status = connection.prepareStatement(
+                    """
+            UPDATE MANUELLOPPGAVE
+            SET sendt_apprec = ?
+            WHERE oppgaveid = ?;
+            """
+            ).use {
+                it.setBoolean(1, sendtApprec)
+                it.setInt(2, oppgaveId)
                 it.executeUpdate()
             }
             connection.commit()

--- a/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
@@ -31,6 +31,7 @@ import no.nav.syfo.model.ReceivedSykmelding
 import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
 import no.nav.syfo.oppgave.service.OppgaveService
+import no.nav.syfo.persistering.db.oppdaterApprecStatus
 import no.nav.syfo.persistering.db.oppdaterManuellOppgave
 import no.nav.syfo.persistering.error.OppgaveNotFoundException
 import no.nav.syfo.util.LoggingMeta
@@ -57,7 +58,7 @@ class ManuellOppgaveService(
             database.erApprecSendt(oppgaveId)
 
     fun toggleApprecSendt(oppgaveId: Int) =
-            database.oppdaterManuellOppgave(oppgaveId, true)
+            database.oppdaterApprecStatus(oppgaveId, true)
 
     suspend fun ferdigstillManuellBehandling(oppgaveId: Int, enhet: String, veileder: Veileder, validationResult: ValidationResult, accessToken: String, merknader: List<Merknad>?) {
         val manuellOppgave = hentManuellOppgave(oppgaveId, accessToken).addMerknader(merknader)

--- a/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
@@ -159,7 +159,6 @@ class ManuellOppgaveService(
         return when (status) {
             Status.OK -> ApprecStatus.OK
             Status.MANUAL_PROCESSING -> ApprecStatus.OK
-            Status.INVALID -> ApprecStatus.AVVIST
             else -> throw IllegalArgumentException("Validation result must be OK or INVALID")
         }
     }

--- a/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
+++ b/src/main/kotlin/no/nav/syfo/service/ManuellOppgaveService.kt
@@ -80,7 +80,6 @@ class ManuellOppgaveService(
               */
 
             sendApprec(oppgaveId, manuellOppgave.apprec, loggingMeta)
-            toggleApprecSendt(oppgaveId)
         }
 
         when (validationResult.status) {
@@ -167,20 +166,12 @@ class ManuellOppgaveService(
             msgTypeBeskrivelse = manuellOppgave.apprec.msgTypeBeskrivelse,
             genDate = manuellOppgave.apprec.genDate,
             msgGenDate = manuellOppgave.apprec.msgGenDate,
-            apprecStatus = getApprecStatus(manuellOppgave.validationResult.status),
+            apprecStatus = ApprecStatus.OK,
             tekstTilSykmelder = "Sykmeldingen er til manuell vurdering for tilbakedatering",
             senderOrganisasjon = manuellOppgave.apprec.senderOrganisasjon,
             mottakerOrganisasjon = manuellOppgave.apprec.mottakerOrganisasjon,
             validationResult = manuellOppgave.validationResult
         )
-
-    private fun getApprecStatus(status: Status): ApprecStatus {
-        return when (status) {
-            Status.OK -> ApprecStatus.OK
-            Status.MANUAL_PROCESSING -> ApprecStatus.OK
-            else -> throw IllegalArgumentException("Validation result must be OK or INVALID")
-        }
-    }
 
     private fun sendReceivedSykmelding(kafkaProducer: KafkaProducers.KafkaRecievedSykmeldingProducer, receivedSykmelding: ReceivedSykmelding, status: Status, loggingMeta: LoggingMeta) {
         val topic = getTopic(status)

--- a/src/main/resources/db/migration/V6__Update_tables.sql
+++ b/src/main/resources/db/migration/V6__Update_tables.sql
@@ -1,2 +1,1 @@
 ALTER TABLE manuelloppgave ADD COLUMN sendt_apprec boolean;
-UPDATE manuelloppgave SET sendt_apprec = true WHERE ferdigstilt = true

--- a/src/main/resources/db/migration/V6__Update_tables.sql
+++ b/src/main/resources/db/migration/V6__Update_tables.sql
@@ -1,0 +1,2 @@
+ALTER TABLE manuelloppgave ADD COLUMN sendt_apprec boolean;
+UPDATE manuelloppgave SET sendt_apprec = true WHERE ferdigstilt = true

--- a/src/test/kotlin/no/nav/syfo/KafkaITTest.kt
+++ b/src/test/kotlin/no/nav/syfo/KafkaITTest.kt
@@ -43,7 +43,8 @@ object KafkaITTest : Spek({
             oppgavebehandlingUrl = "oppgave",
             cluster = "cluster",
             truststore = "",
-            truststorePassword = ""
+            truststorePassword = "",
+            syfoTilgangsKontrollClientUrl = "http://syfotilgangskontroll"
     )
 
     fun Properties.overrideForTest(): Properties = apply {

--- a/src/test/kotlin/no/nav/syfo/api/AuthenticateTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/AuthenticateTest.kt
@@ -75,7 +75,7 @@ object AuthenticateTest : Spek({
 
     beforeEachTest {
         clearAllMocks()
-        database.opprettManuellOppgave(manuellOppgave, oppgaveid)
+        database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, oppgaveid)
         coEvery { syfoTilgangsKontrollClient.sjekkVeiledersTilgangTilPersonViaAzure(any(), any()) } returns Tilgang(true, "")
     }
     afterEachTest {

--- a/src/test/kotlin/no/nav/syfo/api/HenteManuellOppgaverTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/HenteManuellOppgaverTest.kt
@@ -88,7 +88,7 @@ object HenteManuellOppgaverTest : Spek({
             }
 
             it("Skal hente ut manuell oppgave basert på oppgaveid") {
-                database.opprettManuellOppgave(manuellOppgave, oppgaveid)
+                database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, oppgaveid)
                 with(handleRequest(HttpMethod.Get, "/api/v1/manuellOppgave/$oppgaveid") {
                     addHeader(HttpHeaders.Authorization, "Bearer ${generateJWT("2", "clientId")}")
                 }) {
@@ -97,7 +97,7 @@ object HenteManuellOppgaverTest : Spek({
                 }
             }
             it("Skal kaste NumberFormatException når oppgaveid ikke kan parses til int") {
-                database.opprettManuellOppgave(manuellOppgave, oppgaveid)
+                database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, oppgaveid)
                 assertFailsWith<NumberFormatException> {
                     handleRequest(HttpMethod.Get, "/api/v1/manuellOppgave/1h2j32k")
                 }

--- a/src/test/kotlin/no/nav/syfo/api/OpprettManuellOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/OpprettManuellOppgaveTest.kt
@@ -50,6 +50,7 @@ object OpprettManuellOppgaveTest : Spek({
             oppgaveliste[0].apprec shouldEqual apprec
             oppgaveliste[0].receivedSykmelding shouldEqual receivedSykmelding
             oppgaveliste[0].validationResult shouldEqual validationResult
+            oppgaveliste[0].sendtApprec shouldEqual false
         }
         it("Hvis oppgave er lagret for sykmeldingsid skal erOpprettManuellOppgave returnere true") {
             database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, 123144)

--- a/src/test/kotlin/no/nav/syfo/api/OpprettManuellOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/OpprettManuellOppgaveTest.kt
@@ -42,7 +42,7 @@ object OpprettManuellOppgaveTest : Spek({
 
     describe("Test av oppretting av manuelle oppgaver") {
         it("Skal lagre manuellOppgave i databasen og kunne hente den opp som forventet") {
-            database.opprettManuellOppgave(manuellOppgave, 123144)
+            database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, 123144)
 
             val oppgaveliste = database.hentKomplettManuellOppgave(123144)
 
@@ -52,7 +52,7 @@ object OpprettManuellOppgaveTest : Spek({
             oppgaveliste[0].validationResult shouldEqual validationResult
         }
         it("Hvis oppgave er lagret for sykmeldingsid skal erOpprettManuellOppgave returnere true") {
-            database.opprettManuellOppgave(manuellOppgave, 123144)
+            database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, 123144)
 
             database.erOpprettManuellOppgave(manuellOppgave.receivedSykmelding.sykmelding.id) shouldEqual true
         }

--- a/src/test/kotlin/no/nav/syfo/api/SendVurderingManuellOppgaveTest.kt
+++ b/src/test/kotlin/no/nav/syfo/api/SendVurderingManuellOppgaveTest.kt
@@ -50,7 +50,6 @@ import no.nav.syfo.testutil.generateJWT
 import no.nav.syfo.testutil.generateSykmelding
 import no.nav.syfo.testutil.receivedSykmelding
 import org.amshove.kluent.shouldEqual
-import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.RecordMetadata
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
@@ -93,8 +92,6 @@ object SendVurderingManuellOppgaveTest : Spek({
         it("Skal returnere InternalServerError når oppdatering av manuelloppgave sitt ValidationResults feilet fordi oppgave ikke finnes") {
             with(TestApplicationEngine()) {
                 start()
-
-                coEvery { kafkaProducers.kafkaValidationResultProducer.producer } returns mockk<KafkaProducer<String, ValidationResult>>()
 
                 database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, oppgaveid)
 
@@ -261,19 +258,14 @@ fun setUpTest(
     coEvery { kafkaProducers.kafkaApprecProducer.producer } returns mockk()
     coEvery { kafkaProducers.kafkaApprecProducer.sm2013ApprecTopic } returns sm2013ApprecTopicName
 
-    coEvery { kafkaProducers.kafkaValidationResultProducer.producer } returns mockk()
-
     coEvery { kafkaProducers.kafkaRecievedSykmeldingProducer.producer } returns mockk()
     coEvery { kafkaProducers.kafkaRecievedSykmeldingProducer.sm2013AutomaticHandlingTopic } returns sm2013AutomaticHandlingTopic
-    coEvery { kafkaProducers.kafkaRecievedSykmeldingProducer.sm2013InvalidHandlingTopic } returns sm2013InvalidHandlingTopic
-    coEvery { kafkaProducers.kafkaValidationResultProducer.sm2013BehandlingsUtfallTopic } returns sm2013BehandlingsUtfallTopic
     coEvery { syfoTilgangsKontrollClient.sjekkVeiledersTilgangTilPersonViaAzure(any(), any()) } returns Tilgang(true, "")
     coEvery { syfoTilgangsKontrollClient.hentVeilederIdentViaAzure(any()) } returns Veileder("4321")
 
     coEvery { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) } returns CompletableFuture<RecordMetadata>().apply { complete(mockk()) }
     coEvery { oppgaveService.ferdigstillOppgave(any(), any(), any(), any()) } returns Unit
     coEvery { kafkaProducers.kafkaApprecProducer.producer.send(any()) } returns CompletableFuture<RecordMetadata>().apply { complete(mockk()) }
-    coEvery { kafkaProducers.kafkaValidationResultProducer.producer.send(any()) } returns CompletableFuture<RecordMetadata>().apply { complete(mockk()) }
     database.opprettManuellOppgave(manuellOppgave, manuellOppgave.apprec, oppgaveid)
 
     testApplicationEngine.application.routing {

--- a/src/test/kotlin/no/nav/syfo/persistering/HandleReceivedMessageTest.kt
+++ b/src/test/kotlin/no/nav/syfo/persistering/HandleReceivedMessageTest.kt
@@ -2,18 +2,20 @@ package no.nav.syfo.persistering
 
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.util.KtorExperimentalAPI
-import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.UUID
+import java.util.concurrent.CompletableFuture
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.runBlocking
+import no.nav.syfo.aksessering.db.erApprecSendt
 import no.nav.syfo.aksessering.db.hentKomplettManuellOppgave
 import no.nav.syfo.brukernotificasjon.BrukernotifikasjonService
+import no.nav.syfo.client.SyfoTilgangsKontrollClient
+import no.nav.syfo.clients.KafkaProducers
 import no.nav.syfo.model.Apprec
 import no.nav.syfo.model.ManuellOppgave
 import no.nav.syfo.model.RuleInfo
@@ -29,6 +31,7 @@ import no.nav.syfo.testutil.generateSykmelding
 import no.nav.syfo.testutil.receivedSykmelding
 import no.nav.syfo.util.LoggingMeta
 import org.amshove.kluent.shouldEqual
+import org.apache.kafka.clients.producer.RecordMetadata
 import org.spekframework.spek2.Spek
 import org.spekframework.spek2.style.specification.describe
 
@@ -36,7 +39,9 @@ import org.spekframework.spek2.style.specification.describe
 object HandleReceivedMessageTest : Spek({
     val database = TestDB()
     val oppgaveService = mockk<OppgaveService>()
-    val manuellOppgaveServce = mockk<ManuellOppgaveService>()
+    val syfoTilgangsKontrollClient: SyfoTilgangsKontrollClient = mockk<SyfoTilgangsKontrollClient>()
+    val kafkaProducers: KafkaProducers = mockk<KafkaProducers>()
+    val manuellOppgaveService = ManuellOppgaveService(database, syfoTilgangsKontrollClient, kafkaProducers, oppgaveService)
     val brukernotifikasjonService = mockk<BrukernotifikasjonService>(relaxed = true)
     val sykmeldingsId = UUID.randomUUID().toString()
     val msgId = "1314"
@@ -55,8 +60,10 @@ object HandleReceivedMessageTest : Spek({
     beforeEachTest {
         clearAllMocks()
         coEvery { oppgaveService.opprettOppgave(any(), any()) } returns oppgaveid
-        coEvery { manuellOppgaveServce.lagOppdatertApprec(manuellOppgave) } returns manuellOppgave.apprec
-        coEvery { manuellOppgaveServce.sendApprec(any(), any()) } just Runs
+        coEvery { kafkaProducers.kafkaApprecProducer.producer } returns mockk()
+        coEvery { kafkaProducers.kafkaApprecProducer.sm2013ApprecTopic } returns "sm2013AutomaticHandlingTopic"
+        coEvery { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) } returns CompletableFuture<RecordMetadata>().apply { complete(mockk()) }
+        coEvery { kafkaProducers.kafkaApprecProducer.producer.send(any()) } returns CompletableFuture<RecordMetadata>().apply { complete(mockk()) }
     }
 
     afterEachTest {
@@ -69,17 +76,33 @@ object HandleReceivedMessageTest : Spek({
     describe("Test av mottak av ny melding") {
         it("Happy-case") {
             runBlocking {
-                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveServce, brukernotifikasjonService)
+                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveService, brukernotifikasjonService)
             }
 
             database.hentKomplettManuellOppgave(oppgaveid).size shouldEqual 1
             coVerify { oppgaveService.opprettOppgave(any(), any()) }
             verify(exactly = 1) { brukernotifikasjonService.sendBrukerNotifikasjon(any()) }
         }
+
+        it("Apprec oppdateres") {
+            database.erApprecSendt(oppgaveid) shouldEqual false
+
+            runBlocking {
+                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveService, brukernotifikasjonService)
+            }
+
+            val hentKomplettManuellOppgave = database.hentKomplettManuellOppgave(oppgaveid)
+            hentKomplettManuellOppgave.first().sendtApprec shouldEqual true
+            database.erApprecSendt(oppgaveid) shouldEqual true
+
+            coVerify { oppgaveService.opprettOppgave(any(), any()) }
+            verify(exactly = 1) { brukernotifikasjonService.sendBrukerNotifikasjon(any()) }
+        }
+
         it("Lagrer ikke melding som allerede finnes") {
             runBlocking {
-                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveServce, brukernotifikasjonService)
-                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveServce, brukernotifikasjonService)
+                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveService, brukernotifikasjonService)
+                handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveService, brukernotifikasjonService)
             }
 
             database.hentKomplettManuellOppgave(oppgaveid).size shouldEqual 1
@@ -90,7 +113,7 @@ object HandleReceivedMessageTest : Spek({
             coEvery { oppgaveService.opprettOppgave(any(), any()) } throws RuntimeException("Noe gikk galt")
             assertFailsWith<RuntimeException> {
                 runBlocking {
-                    handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveServce, brukernotifikasjonService)
+                    handleReceivedMessage(manuellOppgave, loggingMeta, database, oppgaveService, manuellOppgaveService, brukernotifikasjonService)
                 }
             }
             database.erOpprettManuellOppgave(sykmeldingsId) shouldEqual false

--- a/src/test/kotlin/no/nav/syfo/service/ManuellOppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ManuellOppgaveServiceTest.kt
@@ -1,11 +1,9 @@
 package no.nav.syfo.service
 
 import io.ktor.util.KtorExperimentalAPI
-import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.just
 import io.mockk.mockk
 import java.util.UUID
 import javax.ws.rs.ForbiddenException
@@ -175,6 +173,5 @@ object ManuellOppgaveServiceTest : Spek({
 
             database.erApprecSendt(oppgaveid) shouldEqual true
         }
-
     }
 })

--- a/src/test/kotlin/no/nav/syfo/service/ManuellOppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/service/ManuellOppgaveServiceTest.kt
@@ -20,7 +20,6 @@ import no.nav.syfo.model.Merknad
 import no.nav.syfo.model.RuleInfo
 import no.nav.syfo.model.Status
 import no.nav.syfo.model.ValidationResult
-import no.nav.syfo.objectMapper
 import no.nav.syfo.oppgave.service.OppgaveService
 import no.nav.syfo.persistering.db.opprettManuellOppgave
 import no.nav.syfo.testutil.TestDB
@@ -77,7 +76,6 @@ object ManuellOppgaveServiceTest : Spek({
             }
 
             coVerify { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) }
-            coVerify(exactly = 0) { kafkaProducers.kafkaValidationResultProducer.producer.send(any()) }
             coVerify { kafkaProducers.kafkaSyfoserviceProducer.producer.send(any()) }
             coVerify { oppgaveService.ferdigstillOppgave(any(), any(), any(), any()) }
             val oppgaveliste = database.hentKomplettManuellOppgave(oppgaveid)
@@ -101,7 +99,6 @@ object ManuellOppgaveServiceTest : Spek({
             }
 
             coVerify { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) }
-            coVerify(exactly = 0) { kafkaProducers.kafkaValidationResultProducer.producer.send(any()) }
             coVerify { kafkaProducers.kafkaSyfoserviceProducer.producer.send(any()) }
             coVerify { oppgaveService.ferdigstillOppgave(any(), any(), any(), any()) }
             coVerify { oppgaveService.opprettOppfoligingsOppgave(any(), any(), any(), any()) }
@@ -111,23 +108,6 @@ object ManuellOppgaveServiceTest : Spek({
             oppgaveFraDb.ferdigstilt shouldEqual true
             oppgaveFraDb.validationResult shouldEqual manuellOppgave.validationResult
             oppgaveFraDb.receivedSykmelding.merknader shouldEqual merknader
-            oppgaveFraDb.apprec shouldEqual okApprec()
-        }
-        it("Happy case AVVIST") {
-            runBlocking {
-                manuellOppgaveService.ferdigstillManuellBehandling(oppgaveid, "1234", Veileder("4321"), ValidationResult(Status.INVALID, listOf(RuleInfo("regelnavn", "melding til legen", "melding til bruker", Status.INVALID))), "token", merknader = null)
-            }
-
-            coVerify { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) }
-            coVerify { kafkaProducers.kafkaValidationResultProducer.producer.send(any()) }
-            coVerify(exactly = 0) { kafkaProducers.kafkaSyfoserviceProducer.producer.send(any()) }
-            coVerify { oppgaveService.ferdigstillOppgave(any(), any(), any(), any()) }
-            val oppgaveliste = database.hentKomplettManuellOppgave(oppgaveid)
-            oppgaveliste.size shouldEqual 1
-            val oppgaveFraDb = oppgaveliste.first()
-            println(objectMapper.writeValueAsString(oppgaveFraDb.apprec))
-            oppgaveFraDb.ferdigstilt shouldEqual true
-            oppgaveFraDb.validationResult shouldEqual manuellOppgave.validationResult
             oppgaveFraDb.apprec shouldEqual okApprec()
         }
         it("Feiler hvis validation result er MANUAL_PROCESSING") {
@@ -161,7 +141,6 @@ object ManuellOppgaveServiceTest : Spek({
             }
 
             coVerify { kafkaProducers.kafkaRecievedSykmeldingProducer.producer.send(any()) }
-            coVerify(exactly = 0) { kafkaProducers.kafkaValidationResultProducer.producer.send(any()) }
             coVerify { kafkaProducers.kafkaSyfoserviceProducer.producer.send(any()) }
             coVerify { oppgaveService.ferdigstillOppgave(any(), any(), any(), any()) }
             val oppgaveliste = database.hentKomplettManuellOppgave(oppgaveid)


### PR DESCRIPTION
Fjernet funksjonalitet for å avvise
Apprec sendes ved ingest, i stedet for ved ferdigstilling

Testet OK i Q.

Edit: Må testes på nytt i Q etter databaseendringer. Mañana.